### PR TITLE
加入了分组可变形卷积

### DIFF
--- a/backbones/__init__.py
+++ b/backbones/__init__.py
@@ -1,3 +1,4 @@
 from backbones.resnet import resnet18, resnet34, resnet50, resnet101
 from backbones.seresnet import seresnet18, seresnet34, seresnet50, seresnet101
 from backbones.cbam import cbamres18, cbamres34, cbamres50
+from backbones.resnet_ours import resnet18_3d, resnet34_3d, resnet50_3d, resnet50_3d_de, resnet101_3d, resnet152_3d

--- a/backbones/atten3d.py
+++ b/backbones/atten3d.py
@@ -3,10 +3,8 @@ import torch.nn as nn
 
 
 from torch.autograd import Variable
-#from modules import DeformConv
-
-
-num_deformable_groups = 2  # 这里是可变形分组卷积的组数设置
+from config import cfg
+from backbones.deform_conv import DeformConv2D
 
 
 class ChanelWiseFC(nn.Module):  # 逐通道全连接
@@ -78,23 +76,25 @@ class Conv1x1(nn.Module):  # 1*1卷积
 
 
 class GroupWiseDeformableConv(nn.Module):  # 这个函数不用了，因为官方已经有分组的了
-    def __init__(self, k):
+    def __init__(self, channels, kernel_size=3, stride=1, padding=1):
         super(GroupWiseDeformableConv, self).__init__()
-        self.k = k
-        self.DeformableConv = min(1)  # 这里是引入可变性卷积的地方
+        self.k = cfg.num_deformable_groups
+        self.conv_deformable = nn.Conv2d(channels // self.k, 18, kernel_size=kernel_size, stride=stride, padding=padding)  # 可变形偏移
+        self.conv_offset2d = DeformConv2D(channels // self.k, channels // self.k, kernel_size=kernel_size, padding=padding)  # 这里是已进行偏移后
 
     def forward(self, x):
-        y = torch.split(x, self.k, dim=1)  # 在第一维度(通道)分离出k组
+        y = torch.split(x, x.shape[1] // self.k, dim=1)  # 在第一维度(通道)分离出k组
         list = []
         for i in y:
-            i = self.DeformableConv(i)
-            list.append(i)
+            offset = self.conv_deformable(i)  # 学习偏移
+            output = self.conv_offset2d(i, offset)  # 这里之后就是那个分组可变形卷积的结果
+            list.append(output)
         z = torch.cat(list, dim=1)  # 把前面按通道分裂成k组后的可变性卷积，在通道上拼接，最后形成k组偏移的注意力机制(2*k个偏移量，N是每组的通道数)
         return z
 
 
 class Atten3D(nn.Module):  # 3D Atten模块,(创新点1)
-    def __init__(self, in_planes, inSize, outSize, stage):  # 输入通道数，fc输入尺寸，fc输出,阶段(对应resnet的stage)
+    def __init__(self, in_planes, inSize, outSize, stage, en_defor=False):  # 输入通道数，fc输入尺寸，fc输出,阶段(对应resnet的stage)
         super(Atten3D, self).__init__()
         self.Conv = Conv1x1(in_planes, in_planes // 16, kernel_size=1, stride=1, padding=0)
         self.ChanelWiseConv = ChanelWiseConv(in_planes // 16, kernel_size=3, stride=2, padding=1)
@@ -103,23 +103,9 @@ class Atten3D(nn.Module):  # 3D Atten模块,(创新点1)
         self.ChanelWiseDeConv = ChanelWiseDeConv(in_planes // 16, kernel_size=3, stride=2, padding=1, output_padding=1)
         self.DeConv = Conv1x1(in_planes // 16, in_planes, kernel_size=1, stride=1, padding=0)
         self.stage = stage  # 这个是看stage来设置网络结构的
-
-        #下面两部分是可变形卷积的官方实现(单独测试3D Atten的话，则不引入)
-        """
-        self.conv_deformable = nn.Conv2d(
-            32,#这里是否得考虑其他办法获取输入的通道数
-            num_deformable_groups * 2 * 3 * 3,  # 输出通道，为何要乘kH和kW，他们不是卷积核的尺寸
-            kernel_size=(3, 3),
-            stride=(1, 1),
-            padding=(1, 1),
-            bias=False).cuda()
-        self.conv_offset2d = DeformConv(
-            32,
-            64,#这个输出尺寸到时候看看output的尺寸看是不是并无太大联系(因为输出肯定是2*k*N，若输入为N时)
-            (3, 3),
-            stride=1,
-            padding=1,
-            num_deformable_groups=num_deformable_groups).cuda()"""
+        self.en_defor = en_defor  # 使用可变形卷积
+        # 下面是可变形组卷积的实现(单独测试3D Atten的话，则不引入)
+        self.groupWiseDeformableConv = GroupWiseDeformableConv(in_planes, kernel_size=3, stride=1, padding=1)
 
     def forward(self, x):
         y = self.Conv(x)  # 1*1卷积在四个阶段都有
@@ -133,15 +119,10 @@ class Atten3D(nn.Module):  # 3D Atten模块,(创新点1)
             y = self.ChanelWiseDeConv(y)
         if self.stage==2 or self.stage==3:  # 这里暂定只在stage=2或3的时候用2个逐通道反卷积（其实如果只有一个可以不写这个if）
             y = self.ChanelWiseDeConv(y)
-        y = self.DeConv(y)  # 每个stage都有，这里后期还会替换成可变形卷积(写一个stage4或5的判断)
-        # TODO：究竟要不要反卷积回去再可变形，还是直接可变形？(考虑换一个版本吧，再找找纯pytorch的)
-        """
-         #3D Atten + group deformable Conv（创新点3），这里用的话再修改加上
-         offset = self.conv_deformable(y)#学习偏移
-         output = self.conv_offset2d(y, offset)
-         output.backward(output.data)#这里之后就是那个分组可变形卷积的结果
-         y = output
-        """
+        y = self.DeConv(y)  # 每个stage都有
+        if self.en_defor==True:  #（创新点3）
+            if self.stage==4 or self.stage==5:
+                y = self.groupWiseDeformableConv(y)
         return y
 
 

--- a/backbones/deform_conv.py
+++ b/backbones/deform_conv.py
@@ -1,3 +1,7 @@
+"""
+This code is a copy from https://github.com/ChunhuanLin/deform_conv_pytorch
+"""
+
 from torch.autograd import Variable, Function
 import torch
 from torch import nn

--- a/backbones/deform_conv.py
+++ b/backbones/deform_conv.py
@@ -1,0 +1,128 @@
+from torch.autograd import Variable, Function
+import torch
+from torch import nn
+import numpy as np
+
+
+class DeformConv2D(nn.Module):
+    def __init__(self, inc, outc, kernel_size=3, padding=1, bias=None):
+        super(DeformConv2D, self).__init__()
+        self.kernel_size = kernel_size
+        self.padding = padding
+        self.zero_padding = nn.ZeroPad2d(padding)
+        # 最终输出的卷积层，设置输入通道数和输出通道数
+        self.conv_kernel = nn.Conv2d(inc, outc, kernel_size=kernel_size, stride=kernel_size, bias=bias)
+
+    def forward(self, x, offset):
+        dtype = offset.data.type()
+        ks = self.kernel_size
+        N = offset.size(1) // 2
+
+        # Change offset's order from [x1, x2, ..., y1, y2, ...] to [x1, y1, x2, y2, ...]
+        # Codes below are written to make sure same results of MXNet implementation.
+        # You can remove them, and it won't influence the module's performance.
+        offsets_index = Variable(torch.cat([torch.arange(0, 2*N, 2), torch.arange(1, 2*N+1, 2)]), requires_grad=False).type_as(x).long()
+        offsets_index = offsets_index.unsqueeze(dim=0).unsqueeze(dim=-1).unsqueeze(dim=-1).expand(*offset.size())
+        offset = torch.gather(offset, dim=1, index=offsets_index)
+        # ------------------------------------------------------------------------
+
+        if self.padding:
+            x = self.zero_padding(x)
+
+        # (b, 2N, h, w)
+        p = self._get_p(offset, dtype)
+
+        # (b, h, w, 2N)
+        p = p.contiguous().permute(0, 2, 3, 1)
+        q_lt = Variable(p.data, requires_grad=False).floor()
+        q_rb = q_lt + 1
+
+        q_lt = torch.cat([torch.clamp(q_lt[..., :N], 0, x.size(2)-1), torch.clamp(q_lt[..., N:], 0, x.size(3)-1)], dim=-1).long()
+        q_rb = torch.cat([torch.clamp(q_rb[..., :N], 0, x.size(2)-1), torch.clamp(q_rb[..., N:], 0, x.size(3)-1)], dim=-1).long()
+        q_lb = torch.cat([q_lt[..., :N], q_rb[..., N:]], -1)
+        q_rt = torch.cat([q_rb[..., :N], q_lt[..., N:]], -1)
+
+        # (b, h, w, N)
+        mask = torch.cat([p[..., :N].lt(self.padding)+p[..., :N].gt(x.size(2)-1-self.padding),
+                          p[..., N:].lt(self.padding)+p[..., N:].gt(x.size(3)-1-self.padding)], dim=-1).type_as(p)
+        mask = mask.detach()
+        floor_p = p - (p - torch.floor(p))
+        p = p*(1-mask) + floor_p*mask
+        p = torch.cat([torch.clamp(p[..., :N], 0, x.size(2)-1), torch.clamp(p[..., N:], 0, x.size(3)-1)], dim=-1)
+
+        # bilinear kernel (b, h, w, N)
+        g_lt = (1 + (q_lt[..., :N].type_as(p) - p[..., :N])) * (1 + (q_lt[..., N:].type_as(p) - p[..., N:]))
+        g_rb = (1 - (q_rb[..., :N].type_as(p) - p[..., :N])) * (1 - (q_rb[..., N:].type_as(p) - p[..., N:]))
+        g_lb = (1 + (q_lb[..., :N].type_as(p) - p[..., :N])) * (1 - (q_lb[..., N:].type_as(p) - p[..., N:]))
+        g_rt = (1 - (q_rt[..., :N].type_as(p) - p[..., :N])) * (1 + (q_rt[..., N:].type_as(p) - p[..., N:]))
+
+        # (b, c, h, w, N)
+        x_q_lt = self._get_x_q(x, q_lt, N)
+        x_q_rb = self._get_x_q(x, q_rb, N)
+        x_q_lb = self._get_x_q(x, q_lb, N)
+        x_q_rt = self._get_x_q(x, q_rt, N)
+
+        # (b, c, h, w, N)
+        x_offset = g_lt.unsqueeze(dim=1) * x_q_lt + \
+                   g_rb.unsqueeze(dim=1) * x_q_rb + \
+                   g_lb.unsqueeze(dim=1) * x_q_lb + \
+                   g_rt.unsqueeze(dim=1) * x_q_rt
+
+        x_offset = self._reshape_x_offset(x_offset, ks)
+        out = self.conv_kernel(x_offset)
+
+        return out
+
+    def _get_p_n(self, N, dtype):
+        p_n_x, p_n_y = np.meshgrid(range(-(self.kernel_size-1)//2, (self.kernel_size-1)//2+1),
+                          range(-(self.kernel_size-1)//2, (self.kernel_size-1)//2+1), indexing='ij')
+        # (2N, 1)
+        p_n = np.concatenate((p_n_x.flatten(), p_n_y.flatten()))
+        p_n = np.reshape(p_n, (1, 2*N, 1, 1))
+        p_n = Variable(torch.from_numpy(p_n).type(dtype), requires_grad=False)
+
+        return p_n
+
+    @staticmethod
+    def _get_p_0(h, w, N, dtype):
+        p_0_x, p_0_y = np.meshgrid(range(1, h+1), range(1, w+1), indexing='ij')
+        p_0_x = p_0_x.flatten().reshape(1, 1, h, w).repeat(N, axis=1)
+        p_0_y = p_0_y.flatten().reshape(1, 1, h, w).repeat(N, axis=1)
+        p_0 = np.concatenate((p_0_x, p_0_y), axis=1)
+        p_0 = Variable(torch.from_numpy(p_0).type(dtype), requires_grad=False)
+
+        return p_0
+
+    def _get_p(self, offset, dtype):#获取所有卷积核中心坐标
+        N, h, w = offset.size(1)//2, offset.size(2), offset.size(3)
+
+        # (1, 2N, 1, 1)
+        p_n = self._get_p_n(N, dtype)
+        # (1, 2N, h, w)
+        p_0 = self._get_p_0(h, w, N, dtype)
+        p = p_0 + p_n + offset
+        return p
+
+    def _get_x_q(self, x, q, N):
+        b, h, w, _ = q.size()
+        padded_w = x.size(3)
+        c = x.size(1)
+        # (b, c, h*w)
+        x = x.contiguous().view(b, c, -1)
+
+        # (b, h, w, N)
+        index = q[..., :N]*padded_w + q[..., N:]  # offset_x*w + offset_y
+        # (b, c, h*w*N)
+        index = index.contiguous().unsqueeze(dim=1).expand(-1, c, -1, -1, -1).contiguous().view(b, c, -1)
+
+        x_offset = x.gather(dim=-1, index=index).contiguous().view(b, c, h, w, N)
+
+        return x_offset
+
+    @staticmethod
+    def _reshape_x_offset(x_offset, ks):
+        b, c, h, w, N = x_offset.size()
+        x_offset = torch.cat([x_offset[..., s:s+ks].contiguous().view(b, c, h, w*ks) for s in range(0, N, ks)], dim=-1)
+        x_offset = x_offset.contiguous().view(b, c, h*ks, w*ks)
+
+        return x_offset

--- a/backbones/resnet_ours.py
+++ b/backbones/resnet_ours.py
@@ -128,28 +128,28 @@ class ResNet(nn.Module):
             raise ValueError
 
         # --------------------------stage 2------------------------------
-        self.Atten2 = Atten3D(64, self.fc_size, 12, 2) if self.en_atten3d else nn.Identity()  # 输出为32*32*64
+        self.Atten2 = Atten3D(64, self.fc_size, 12, 2, self.en_defor) if self.en_atten3d else nn.Identity()  # 输出为32*32*64
         self.upsample2 = nn.ConvTranspose2d(64, 3, kernel_size=3, stride=1, padding=1)  # conv1的对应deconv(这是使用ER LOSS才用的),针对ImageNet的
         self.conv2_x = self._make_layer(block, 64, num_block[0], 1)  #输出为32*32*256
         # 全部stride改为1，提前下采样，不用在bottleneck里面下采样(因为要满足3D Atten的输入尺寸)
         self.down2 = nn.Conv2d(64 * self.expansion, 64 * self.expansion, kernel_size=1, stride=2, bias=False)  # 输出为16*16*256
 
         #--------------------------stage 3------------------------------
-        self.Atten3 = Atten3D(64 * self.expansion, self.fc_size // 2, 3, 3) if self.en_atten3d else nn.Identity()  # 输出为16*16*256
+        self.Atten3 = Atten3D(64 * self.expansion, self.fc_size // 2, 3, 3, self.en_defor) if self.en_atten3d else nn.Identity()  # 输出为16*16*256
         self.upsample3 = nn.ConvTranspose2d(64 * self.expansion, 64, kernel_size=1, stride=2, padding=0,
                                             output_padding=1)  # 3D Atten的反卷积，(这是使用ER LOSS才用的)
         self.conv3_x = self._make_layer(block, 128, num_block[1], 1)  # 输出为16*16*512
         self.down3 = nn.Conv2d(128 * self.expansion, 128 * self.expansion, kernel_size=1, stride=2, bias=False)  # 输出为8*8*512
 
         # --------------------------stage 4------------------------------
-        self.Atten4 = Atten3D(128 * self.expansion, self.fc_size // 2, 3, 4) if self.en_atten3d else nn.Identity()  # 输出为8*8*512
+        self.Atten4 = Atten3D(128 * self.expansion, self.fc_size // 2, 3, 4, self.en_defor) if self.en_atten3d else nn.Identity()  # 输出为8*8*512
         self.upsample4 = nn.ConvTranspose2d(128 * self.expansion, 64 * self.expansion, kernel_size=1, stride=2, padding=0,
                                             output_padding=1)  # 3D Atten的反卷积(ER LOSS使用)
         self.conv4_x = self._make_layer(block, 256, num_block[2], 1)  # 输出为8*8*1024
         self.down4 = nn.Conv2d(256 * self.expansion, 256 * self.expansion, kernel_size=1, stride=2, bias=False)  # 输出为4*4*1024
 
         # --------------------------stage 5------------------------------
-        self.Atten5 = Atten3D(256 * self.expansion, self.fc_size // 2, 3, 5) if self.en_atten3d else nn.Identity()  # 输出为4*4*1024
+        self.Atten5 = Atten3D(256 * self.expansion, self.fc_size // 2, 3, 5, self.en_defor) if self.en_atten3d else nn.Identity()  # 输出为4*4*1024
         self.upsample5 = nn.ConvTranspose2d(256 * self.expansion, 128 * self.expansion, kernel_size=1, stride=2, padding=0,
                                             output_padding=1)  # 3D Atten的反卷积(ER LOSS使用)
         self.conv5_x = self._make_layer(block, 512, num_block[3], 1)  # 输出为4*4*2048

--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ cfg.nw = 20
 
 cfg.re_p = 0.  # Random Erasing p
 cfg.en_erloss = False  # ER_LOSS
+cfg.num_deformable_groups = 2  # group of deformConv
 
 """ Setting EXP ID """
 cfg.exp_id = 3

--- a/train.py
+++ b/train.py
@@ -83,7 +83,8 @@ def main(args):
 
     backbone = eval("backbones.{}".format(args.network))(
         fp16=cfg.fp16,
-        num_classes=cfg.num_classes
+        num_classes=cfg.num_classes,
+        num_group=cfg.num_deformable_groups,
     ).to(local_rank)
 
     if args.resume:


### PR DESCRIPTION
1.deform_conv.py是在github上找的纯pytorch实现；
2.config.py上加入了cfg.num_deformable_groups，表示分组数量
3.attend3d.py在Atten3D上的stage4/5加入判断是否加入分组可变形卷积
4.resnet_ours.py在Atten3D上传入self.en_defor参数来判断是否启动分组可变形卷积。